### PR TITLE
Fix for nil maxValue

### DIFF
--- a/salesboard.rb
+++ b/salesboard.rb
@@ -69,7 +69,7 @@ months = {
 options = { :basic_auth => { :username => userName , :password => password } }
 datasequences = []
 minTotal = 0
-maxTotal = 0
+maxTotal = 1
 
 # Iterate through each product listed above. 
 products.each do |p|


### PR DESCRIPTION
Set default maxTotal to stop JSON error when maxValue isn't greater
than minValue. Issue arose when no values greater than 0 are received from appfigures.com
